### PR TITLE
Fix URL encoding error

### DIFF
--- a/src/requestHandler.js
+++ b/src/requestHandler.js
@@ -108,7 +108,8 @@ async function parseRequest(req) {
         .split('&')
         .filter(s => s != '')
         .map(x => x.split('='))
-        .reduce((p, [k, v]) => Object.assign(p, { [k]: decodeURIComponent(v) }), {});
+        .reduce((p, [k, v]) => Object.assign(p, { [k]: decodeURIComponent(v.replace(/\+/g, " ")) }), {});
+
     const body = await parseBody(req);
 
     return {


### PR DESCRIPTION
Link: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#decoding_query_parameters_from_a_url
DecodeURIComponent() cannot be used directly to parse query parameters from a URL. It needs a bit of preparation.

Closes #7  