### PR TITLE
Add filtering and sorting support to JSON Store REST service #23 #25

### DIFF
--- a/JSONSTORE.md
+++ b/JSONSTORE.md
@@ -35,6 +35,41 @@ Retrieve entry with ID **"asdf-1234"** from the `books` collection:
 - **Method:** `GET`
 - **Endpont:** `/jsonstore/books/asdf-1234`
 
+**Sorting**
+
+You can sort the returned results by adding a sortBy query parameter.
+- Ascending order (default): `?sortBy=field`
+- Descending order: `?sortBy=field%20desc`
+
+Sorting works with both numeric and string fields:
+- Numeric fields are sorted mathematically (1, 2, 10, 20...)
+- String fields are sorted alphabetically using localeCompare
+
+**Sorting Examples**
+
+Sort phonebook by person in ascending order:
+- **Method:** `GET`
+- **Endpoint:** `/jsonstore/phonebook?sortBy=person`
+
+Sort games by _createdOn in descending order:
+
+- **Method:** `GET`
+- **Endpoint:** `/jsonstore/games?sortBy=_createdOn%20desc`
+
+Sort books by author name:
+
+- **Method:** `GET`
+- **Endpoint:** `/jsonstore/books?sortBy=author`
+
+**Filtering (WHERE)**
+
+You can filter results using the where query parameter with field and value.
+The format is:
+`?where=field%3D%22value%22`
+
+**Filtering Example**
+- **Method:** `GET`
+- **Endpoint:** `/jsonstore/comments?where=gameId%3D%22{gameId}%22`
 
 ### Create
 

--- a/src/requestHandler.js
+++ b/src/requestHandler.js
@@ -106,16 +106,13 @@ async function parseRequest(req) {
     let query = '';
     try {
         query = queryString
-            .split('&')
-            .filter(s => s != '')
-            .map((x) => {
-                const parts = x.split('=');
-                return parts
-            })
-            .reduce((p, [k, v]) => Object.assign(p, { [k]: decodeURIComponent(v.replace(/\+/g, " ")) }), {});
+        .split('&')
+        .filter(s => s != '')
+        .map(x => x.split('='))
+        .reduce((p, [k, v]) => Object.assign(p, { [k]: decodeURIComponent(v.replace(/\+/g, " ")) }), {});
     } catch (err) {
         console.error(err);
-        throw new RequestError(`Invalid query ${queryString}`);
+        throw new RequestError(`Invalid query "${queryString}": ${err.message}`);
     }    
     let body;
     // If req stream has ended body has been parsed

--- a/src/services/jsonstore.js
+++ b/src/services/jsonstore.js
@@ -22,6 +22,35 @@ const actions = {
                 responseData = responseData[token];
             }
         }
+
+        if (query.where && typeof responseData === 'object') {
+            const [field, rawValue] = query.where.split("=");
+            const value = rawValue.replace(/^"|"$/g, "");
+
+            const filtered = Object.entries(responseData)
+                .filter(([id, obj]) => obj[field] == value);
+
+            responseData = Object.fromEntries(filtered);
+        }
+
+        if (query.sortBy && typeof responseData === 'object') {
+            const [field, direction] = query.sortBy.split(' ');
+            const sortOrder = direction === 'desc' ? -1 : 1;
+
+            const entries = Object.entries(responseData).sort(([idA, a], [idB, b]) => {
+                const valA = a[field];
+                const valB = b[field];
+
+                const isNumber = typeof valA === 'number' && typeof valB === 'number';
+                return (isNumber
+                    ? valA - valB
+                    : String(valA).localeCompare(String(valB))
+                ) * sortOrder;
+            });
+
+            responseData = Object.fromEntries(entries);
+        }
+
         return responseData;
     },
     post: (context, tokens, query, body) => {

--- a/src/services/jsonstore.js
+++ b/src/services/jsonstore.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const Service = require('./Service');
 const uuid = require('../common/util').uuid;
+const { RequestError } = require('../common/errors');
 
 
 const data = fs.existsSync('./data') ? fs.readdirSync('./data').reduce((p, c) => {
@@ -23,34 +24,59 @@ const actions = {
             }
         }
 
-        if (query.where && typeof responseData === 'object') {
-            const [field, rawValue] = query.where.split("=");
-            const value = rawValue.replace(/^"|"$/g, "");
+        try {
+            if (query.where && typeof responseData === 'object') {
+                if (query.where.trim() === '') {
+                    throw new Error(`Invalid WHERE queryString syntax`);
+                }
+                const [field, rawValue] = query.where.split("=");
 
-            const filtered = Object.entries(responseData)
-                .filter(([id, obj]) => obj[field] == value);
+                if (field.trim() === "") {
+                    throw new Error(`Field can not be empty string: ${query.where}`);
+                }
 
-            responseData = Object.fromEntries(filtered);
+                if (!rawValue) {
+                    throw new RequestError(`Missing "=" %3D between field and value: ${query.where}`);
+                }
+
+                if (!(rawValue.startsWith('"') && rawValue.endsWith('"'))) {
+                    throw new RequestError(`WHERE value must be in quotes %22 : ${query.where}`);
+                }
+                const value = rawValue.replace(/^"|"$/g, "");
+
+                const filtered = Object.entries(responseData)
+                    .filter(([id, obj]) => obj[field] == value);
+
+                responseData = Object.fromEntries(filtered);
+            }
+
+            if (query.sortBy && typeof responseData === 'object') {
+                const [field, direction] = query.sortBy.split(' ');
+
+                if (!field) {
+                    throw new Error(`Invalid sortBy syntax: ${query.sortBy}`);
+                }
+
+                const sortOrder = direction === 'desc' ? -1 : 1;
+
+                const entries = Object.entries(responseData).sort(([idA, a], [idB, b]) => {
+                    const valA = a[field];
+                    const valB = b[field];
+
+                    const isNumber = typeof valA === 'number' && typeof valB === 'number';
+                    return (isNumber
+                        ? valA - valB
+                        : valA.localeCompare(valB)
+                    ) * sortOrder;
+                });
+
+                responseData = Object.fromEntries(entries);
+            }
+        } catch (err) {
+            console.error(err);
+            throw new RequestError(err.message || "Invalid query");
         }
-
-        if (query.sortBy && typeof responseData === 'object') {
-            const [field, direction] = query.sortBy.split(' ');
-            const sortOrder = direction === 'desc' ? -1 : 1;
-
-            const entries = Object.entries(responseData).sort(([idA, a], [idB, b]) => {
-                const valA = a[field];
-                const valB = b[field];
-
-                const isNumber = typeof valA === 'number' && typeof valB === 'number';
-                return (isNumber
-                    ? valA - valB
-                    : String(valA).localeCompare(String(valB))
-                ) * sortOrder;
-            });
-
-            responseData = Object.fromEntries(entries);
-        }
-
+        
         return responseData;
     },
     post: (context, tokens, query, body) => {


### PR DESCRIPTION
## Changes
- Added `sortBy` query parameter support for sorting by field (asc/desc)
- Added `where` query parameter support for filtering by field/value pairs
- Updated README with documentation and usage examples

## Usage
GET `/jsonstore/games?sortBy=_createdOn%20desc`
GET` /jsonstore/comments?where=gameId%3D%22{gameId}%22`

Closes #23
Closes #25